### PR TITLE
Include Alembic migrations in Vercel build

### DIFF
--- a/poker-ledger-backend/vercel.json
+++ b/poker-ledger-backend/vercel.json
@@ -7,7 +7,8 @@
   ],
   "functions": {
     "api/index.py": {
-      "maxDuration": 30
+      "maxDuration": 30,
+      "includeFiles": "alembic/**"
     }
   }
-} 
+}


### PR DESCRIPTION
## Summary
- add `includeFiles` to Vercel config so Alembic migrations deploy with the API function

## Testing
- `vercel build` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c7cb864b50832daeaf04d46936e11a